### PR TITLE
remove `"orientation": "any"` from `manifest.json`

### DIFF
--- a/applet/manifest.json
+++ b/applet/manifest.json
@@ -82,7 +82,6 @@
 	"background_color": "#000000",
 	"theme_color": "#3E5F8A",
 	"display": "standalone",
-	"orientation": "any",
 	"start_url": "../ui3.htm",
 	"id": "/ui3.htm",
 	"scope": "%%VIRTDIR%%"


### PR DESCRIPTION
`"orientation": "any"` causes Android (and probably iOS) to ignore the OS rotation lock setting, and always rotate regardless of if the user wants their screen to be rotated.

Fixes Issue #144 